### PR TITLE
Easier and more explicit requires

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,6 @@ Or install it yourself as:
 Add an initializer:
 
     require "rails/mailpack/all"
-    ActionMailer::Base.register_interceptor HtmlLinksToTextInterceptor
-    ActionMailer::Base.register_preview_interceptor HtmlLinksToTextInterceptor
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Mailpack stands on the shoulders of giants:
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'rails-mailpack'
+gem "rails-mailpack", :require => false
 ```
 
 And then execute:
@@ -86,6 +86,7 @@ Or install it yourself as:
 
 Add an initializer:
 
+    require "rails/mailpack/all"
     ActionMailer::Base.register_interceptor HtmlLinksToTextInterceptor
     ActionMailer::Base.register_preview_interceptor HtmlLinksToTextInterceptor
 

--- a/lib/rails/mailpack.rb
+++ b/lib/rails/mailpack.rb
@@ -1,7 +1,12 @@
+# frozen_string_literal: true
+
+$:.push File.expand_path("..", __FILE__)
+
 require "rails/mailpack/version"
+
+autoload :HtmlLinksToTextInterceptor, 'html_links_to_text_interceptor'
 
 module Rails
   module Mailpack
-    # Your code goes here...
   end
 end

--- a/lib/rails/mailpack/all.rb
+++ b/lib/rails/mailpack/all.rb
@@ -3,3 +3,7 @@
 require "html_links_to_text_interceptor"
 require "markerb"
 require "premailer/rails"
+
+# Convert html links to text links
+ActionMailer::Base.register_interceptor HtmlLinksToTextInterceptor
+ActionMailer::Base.register_preview_interceptor HtmlLinksToTextInterceptor

--- a/lib/rails/mailpack/all.rb
+++ b/lib/rails/mailpack/all.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+require "html_links_to_text_interceptor"
+require "markerb"
+require "premailer/rails"

--- a/lib/rails_mailpack.rb
+++ b/lib/rails_mailpack.rb
@@ -1,2 +1,0 @@
-$:.push File.expand_path("..", __FILE__)
-autoload :HtmlLinksToTextInterceptor, 'html_links_to_text_interceptor'


### PR DESCRIPTION
With this change we're opening up for the possibility to require just the parts
of rails-mailpack that you actually want to use in your app.

To begin with, we're supporting

```
require "rails/mailpack/all"
```

that imports everything.

Already now the user could do for example

```
# Gemfile
gem "rails-mailpack", :require => false

# config/initializers/mailpack.rb
require "markerb"
```

to require just the markerb stuff. They'd probably be better off just requiring
the markerb gem directly, though. A better example might be when you don't want
for example markerb, you could do

```
# Gemfile
gem "rails-mailpack", :require => false

# config/initializers/mailpack.rb
require "html_links_to_text_interceptor"
require "premailer/rails"
```

which would prevent markerb from being loaded.
