### PR TITLE
Relax dependencies

### DIFF
--- a/rails-mailpack.gemspec
+++ b/rails-mailpack.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "nokogiri"
   spec.add_dependency "premailer-rails"
 
-  spec.add_development_dependency "bundler", "~> 1.12"
-  spec.add_development_dependency "rake", "~> 13.0"
+  spec.add_development_dependency "bundler", ">= 1.12"
+  spec.add_development_dependency "rake", ">= 10.0"
   spec.add_development_dependency "minitest"
 end


### PR DESCRIPTION
Newer versions of both Bundler and Rake have been released, which we support
just fine, while still supporting the older versions.